### PR TITLE
Added class methods support

### DIFF
--- a/delivered.gemspec
+++ b/delivered.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.summary       = 'Simple runtime type checking for Ruby method signatures'
   s.required_ruby_version = '>= 3.2'
 
-  a.metadata['homepage_uri'] = spec.homepage
-  a.metadata['source_code_uri'] = spec.homepage
-  a.metadata['changelog_uri'] = "#{spec.homepage}/releases"
+  s.metadata['homepage_uri'] = s.homepage
+  s.metadata['source_code_uri'] = s.homepage
+  s.metadata['changelog_uri'] = "#{s.homepage}/releases"
 
   s.files         = Dir.glob('{bin/*,lib/**/*,[A-Z]*}')
   s.platform      = Gem::Platform::RUBY

--- a/lib/delivered/signature.rb
+++ b/lib/delivered/signature.rb
@@ -6,7 +6,7 @@ module Delivered
 
     def sig(*sig_args, returns: NULL, **sig_kwargs)
       meta = class << self; self; end
-      sig_check = ->(klass, name, *args, **kwargs, &block) {
+      sig_check = lambda { |klass, name, *args, **kwargs, &block|
         sig_args.each.with_index do |arg, i|
           args[i] => ^arg
         end

--- a/lib/delivered/signature.rb
+++ b/lib/delivered/signature.rb
@@ -6,28 +6,44 @@ module Delivered
 
     def sig(*sig_args, returns: NULL, **sig_kwargs)
       meta = class << self; self; end
+      sig_check = ->(klass, name, *args, **kwargs, &block) {
+        sig_args.each.with_index do |arg, i|
+          args[i] => ^arg
+        end
+
+        kwargs.each do |key, value|
+          value => ^(sig_kwargs[key])
+        end
+
+        result = if block
+                   klass.send(:"__#{name}", *args, **kwargs, &block)
+                 else
+                   klass.send(:"__#{name}", *args, **kwargs)
+                 end
+
+        result => ^returns if returns != NULL
+
+        result
+      }
       meta.send :define_method, :method_added do |name|
         meta.send :remove_method, :method_added
+        meta.send :remove_method, :singleton_method_added
 
         alias_method :"__#{name}", name
         define_method name do |*args, **kwargs, &block|
-          sig_args.each.with_index do |arg, i|
-            args[i] => ^arg
-          end
+          sig_check.call(self, name, *args, **kwargs, &block)
+        end
+      end
 
-          kwargs.each do |key, value|
-            value => ^(sig_kwargs[key])
-          end
+      meta.send :define_method, :singleton_method_added do |name|
+        next if name == :singleton_method_added
 
-          result = if block
-                     send(:"__#{name}", *args, **kwargs, &block)
-                   else
-                     send(:"__#{name}", *args, **kwargs)
-                   end
+        meta.send :remove_method, :singleton_method_added
+        meta.send :remove_method, :method_added
 
-          result => ^returns if returns != NULL
-
-          result
+        meta.alias_method :"__#{name}", name
+        define_singleton_method name do |*args, **kwargs, &block|
+          sig_check.call(self, name, *args, **kwargs, &block)
         end
       end
     end

--- a/test/delivered/signature.rb
+++ b/test/delivered/signature.rb
@@ -23,13 +23,13 @@ describe Delivered::Signature do
     sig Integer, returns: Integer
     attr_writer :age
 
-    sig String, age: Integer, returns: Array
-    def self.where(_name, age: nil)
+    sig String, _age: Integer, returns: Array
+    def self.where(_name, _age: nil)
       []
     end
-    
+
     sig String, returns: Array
-    def find_by_name(name)
+    def self.find_by_name(name)
       User.new(name)
     end
   end
@@ -79,8 +79,7 @@ describe Delivered::Signature do
 
   with 'class methods' do
     it 'supports class method signatures' do
-      users = User.where('Joel')
-      expect(users.length).to be == 0
+      expect(User.where('Joel')).to be == []
     end
 
     it 'raises on incorrect return type' do
@@ -96,11 +95,11 @@ describe Delivered::Signature do
     end
 
     it 'supports keyword args' do
-      expect(User.where('hugo', age: 27)).to be == []
+      expect(User.where('hugo', _age: 27)).to be == []
     end
 
     it 'raises on incorrect kwarg type' do
-      expect { User.where(1, age: 'twentyseven') }.to raise_exception NoMatchingPatternError
+      expect { User.where(1, _age: 'twentyseven') }.to raise_exception NoMatchingPatternError
     end
   end
 end

--- a/test/delivered/signature.rb
+++ b/test/delivered/signature.rb
@@ -22,6 +22,16 @@ describe Delivered::Signature do
 
     sig Integer, returns: Integer
     attr_writer :age
+
+    sig String, age: Integer, returns: Array
+    def self.where(_name, age: nil)
+      []
+    end
+    
+    sig String, returns: Array
+    def find_by_name(name)
+      User.new(name)
+    end
   end
 
   it 'supports positional args' do
@@ -65,5 +75,32 @@ describe Delivered::Signature do
 
   it 'raises on incorrect kwarg type' do
     expect { User.new('Joel', town: 1) }.to raise_exception NoMatchingPatternError
+  end
+
+  with 'class methods' do
+    it 'supports class method signatures' do
+      users = User.where('Joel')
+      expect(users.length).to be == 0
+    end
+
+    it 'raises on incorrect return type' do
+      expect { User.find_by_name('Hugo') }.to raise_exception NoMatchingPatternError
+    end
+
+    it 'raises on missing args' do
+      expect { User.where }.to raise_exception NoMatchingPatternError
+    end
+
+    it 'raises on incorrect arg type' do
+      expect { User.where(1) }.to raise_exception NoMatchingPatternError
+    end
+
+    it 'supports keyword args' do
+      expect(User.where('hugo', age: 27)).to be == []
+    end
+
+    it 'raises on incorrect kwarg type' do
+      expect { User.where(1, age: 'twentyseven') }.to raise_exception NoMatchingPatternError
+    end
   end
 end


### PR DESCRIPTION
# Summary 
Solves #3 . it attempts to refactor the `sig` method to cover for class methods along with adding specs for it. Another early approach was to use a separate `class_sig` method, but I thought that could end up being too confusing

Also addresses some errors I found when check the gemspec while installing local dependencies, but let me know if that's not needed for whatever reason

